### PR TITLE
Add decorator based schema creation with sequelize-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,16 @@
     "dotenv": "^8.2.0",
     "pg": "^8.2.1",
     "pg-hstore": "^2.3.3",
+    "reflect-metadata": "^0.1.13",
     "sequelize": "^5.21.13",
+    "sequelize-typescript": "^1.1.0",
     "typescript": "^3.9.5"
   },
   "devDependencies": {
     "@types/dotenv": "^8.2.0",
     "@types/node": "^14.0.13",
     "@types/sequelize": "^4.28.9",
+    "@types/validator": "^13.0.0",
     "@typescript-eslint/eslint-plugin": "^3.3.0",
     "@typescript-eslint/parser": "^3.3.0",
     "eslint": "^7.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import * as ORM from "sequelize";
+import { Sequelize } from "sequelize-typescript";
+import { User, UserSchema } from "./models/user";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require("dotenv").config();
 
@@ -34,7 +35,7 @@ if (!DB_PORT || isNaN(DB_PORT as any)) {
   );
 }
 
-const connection = new ORM.Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
+const connection = new Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
   dialect: "postgres",
   host: DB_HOST,
   port: Number(DB_PORT),
@@ -46,34 +47,20 @@ const connection = new ORM.Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
   },
 });
 
-class User extends ORM.Model {}
-User.init(
-  {
-    // attributes
-    firstName: {
-      type: ORM.STRING,
-      allowNull: false,
-    },
-    lastName: {
-      type: ORM.STRING,
-    },
-  },
-  {
-    modelName: "userlogin",
-    timestamps: true,
-    sequelize: connection,
-    // options
-  }
-);
+connection.addModels([User]);
+
+const john: UserSchema = {
+  firstName: "John",
+  lastName: "Doe",
+};
 
 (async () => {
   await connection.sync({
     force: true,
     logging: console.log,
   });
-  const user = await User.create({
-    firstName: "John",
-    lastName: "Doe",
-  });
+  const dbVersion = await connection.databaseVersion();
+  console.log(`Database version: ${dbVersion}`);
+  const user = await User.create(john);
   console.log(user);
 })();

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,55 @@
+import {
+  Table,
+  Model,
+  AllowNull,
+  Column,
+  TableOptions,
+  CreatedAt,
+  UpdatedAt,
+  DeletedAt,
+  PrimaryKey,
+  IsUUID,
+} from "sequelize-typescript";
+import { UUID, UUIDV4 } from "sequelize";
+
+const tableOptions: TableOptions = {
+  modelName: "userlogin",
+  timestamps: true,
+};
+
+export interface BaseSchema {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date;
+}
+
+export interface UserSchema extends Partial<BaseSchema> {
+  firstName: string;
+  lastName?: string;
+}
+
+@Table(tableOptions)
+export class User extends Model<User> implements UserSchema {
+  @PrimaryKey
+  @IsUUID(4)
+  @Column({ type: UUID, defaultValue: UUIDV4 })
+  id!: string;
+
+  @AllowNull(false)
+  @Column
+  firstName!: string;
+
+  @AllowNull(true)
+  @Column
+  lastName?: string;
+
+  @CreatedAt
+  createdAt: Date;
+
+  @UpdatedAt
+  updatedAt: Date;
+
+  @DeletedAt
+  deletedAt: Date;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,8 @@
     "strictNullChecks": true /* Enable strict null checks. */,
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    "strictPropertyInitialization": false,
+    /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,7 +87,7 @@
     "@types/lodash" "*"
     "@types/validator" "*"
 
-"@types/validator@*":
+"@types/validator@*", "@types/validator@^13.0.0":
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.0.0.tgz#365f1bf936aeaddd0856fc41aa1d6f82d88ee5b3"
   integrity sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==
@@ -650,6 +650,18 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob@7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.1.3, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -1180,6 +1192,11 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+reflect-metadata@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
+  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
+
 regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
@@ -1258,6 +1275,13 @@ sequelize-pool@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/sequelize-pool/-/sequelize-pool-2.3.0.tgz#64f1fe8744228172c474f530604b6133be64993d"
   integrity sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA==
+
+sequelize-typescript@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sequelize-typescript/-/sequelize-typescript-1.1.0.tgz#d5c2945e7fbfe55a934917b27d84589858d79123"
+  integrity sha512-FAPEQPeAhIaFQNLAcf9Q2IWcqWhNcvn5OZZ7BzGB0CJMtImIsGg4E/EAb7huMmPaPwDArxJUWGqk1KurphTNRA==
+  dependencies:
+    glob "7.1.2"
 
 sequelize@^5.21.13:
   version "5.21.13"


### PR DESCRIPTION
Makes it easy to create schema in the form of a class, in a separate file, with some decorators